### PR TITLE
Rewrite errorformat to handle multi-line GHCi messages

### DIFF
--- a/plugin/ghci.vim
+++ b/plugin/ghci.vim
@@ -32,18 +32,25 @@ command! -nargs=0 -bang GhciRestart call ghci#process#restart()
 
 if g:ghci_use_neomake
     " Neomake integration
+
+    " Try GHC 8 errors and warnings, then GHC 7 errors and warnings, and regard
+    " lines starting with two spaces as continuations on an error message. All
+    " other lines are disregarded. This gives a clean one-line-per-entry in the
+    " QuickFix list.
+    let s:efm = '%E%f:%l:%c:\ error:%#,' .
+                \ '%W%f:%l:%c:\ warning:%#,' .
+                \ '%f:%l:%c:\ %trror: %m,' .
+                \ '%f:%l:%c:\ %tarning: %m,' .
+                \ '%E%f:%l:%c:%#,' .
+                \ '%E%f:%l:%c:%m,' .
+                \ '%W%f:%l:%c:\ Warning:%#,' .
+                \ '%C\ \ %m%#,' .
+                \ '%-G%.%#'
+
     let g:neomake_ghci_maker = {
             \ 'exe': 'cat',
             \ 'args': [ghci#maker#get_log_file()],
-            \ 'errorformat':
-                \ '%-G%\s%#,' .
-                \ '%f:%l:%c:%trror: %m,' .
-                \ '%f:%l:%c:%tarning: %m,'.
-                \ '%f:%l:%c: %trror: %m,' .
-                \ '%f:%l:%c: %tarning: %m,' .
-                \ '%E%f:%l:%c:%m,' .
-                \ '%E%f:%l:%c:,' .
-                \ '%Z%m'
+            \ 'errorformat': s:efm
         \ }
 endif
 

--- a/plugin/ghci.vim
+++ b/plugin/ghci.vim
@@ -39,6 +39,7 @@ if g:ghci_use_neomake
     " QuickFix list.
     let s:efm = '%E%f:%l:%c:\ error:%#,' .
                 \ '%W%f:%l:%c:\ warning:%#,' .
+                \ '%W%f:%l:%c:\ warning:\ [-W%.%#]%#,' .
                 \ '%f:%l:%c:\ %trror: %m,' .
                 \ '%f:%l:%c:\ %tarning: %m,' .
                 \ '%E%f:%l:%c:%#,' .


### PR DESCRIPTION
I've tried to create a more solid error format that collects all error/warning message lines into single entries, to fix #3.

What previously ended up in the QuickFix list as: 

```
|| [1 of 1] Compiling Test ( Test.hs, Test.o )
Test.hs|4 col 7 error| error: • No instance for (Num String) arising from the literal ‘1’
|| • In the expression: 1
|| In an equation for ‘foo’: foo = 1
Test.hs|7 col 7 error| error: • No instance for (Num ()) arising from a use of ‘+’
|| • In the expression: 1 + ()
|| In an equation for ‘bar’: bar = 1 + ()
|| Failed, modules loaded: none.
```

Now becomes:

```
Test.hs|4 col 7 error| • No instance for (Num String) arising from the literal ‘1’ • In the expression: 1 In an equation for ‘foo’: foo = 1
Test.hs|7 col 7 error| • No instance for (Num ()) arising from a use of ‘+’ • In the expression: 1 + () In an equation for ‘bar’: bar = 1 + ()
```

I like this better. Collecting multiple lines into one makes readability slightly worse perhaps, but it feels simpler this way. What do you think @adelbertc?

Test with GHC 7.10.2 and GHC 8.0.2 (which have different error message formats).